### PR TITLE
Fix floating-point precision in payment amount aggregation

### DIFF
--- a/src/__tests__/floatPrecision.test.ts
+++ b/src/__tests__/floatPrecision.test.ts
@@ -1,0 +1,45 @@
+import { MasaVSendPayments, InstitutionSendPayment, SendPaymentsRecord, MasaVGetPayments } from "../index";
+import InstitutionGetPayment from "../institutionGetPayment";
+import GetPaymentsRecord from "../getPaymentRecord";
+
+// 40 payments of 19.90 sum to 795.99999999999943 in naive float
+// accumulation, so the file would contain 795.00 instead of 796.00
+const AMOUNTS = Array(40).fill(19.9);
+
+function sumRecord(buffer: Buffer): string {
+  const line = buffer.toString("ascii").split("\r\n").find((l) => l.startsWith("512345678"));
+  if (!line) throw new Error("sum record not found");
+  return line;
+}
+
+test("get file: 40 payments of 19.90 sum to exactly 796.00", () => {
+  const masavFile = new MasaVGetPayments();
+  const institution = new InstitutionGetPayment(
+    "12345678", "12345", "200507", "200507", "Company ISRAEL LTD.", "404"
+  );
+  institution.addPaymentRecords(
+    AMOUNTS.map((amount, i) => new GetPaymentsRecord(
+      "11", "303", "007008629", "123123127", `Payee ${i}`, "00000000000001313131", amount
+    ))
+  );
+  masavFile.addInstitution(institution);
+  const record = sumRecord(masavFile.toBuffer());
+  expect(record.slice(36, 49)).toBe("0000000000796");
+  expect(record.slice(49, 51)).toBe("00");
+});
+
+test("send file: 40 payments of 19.90 sum to exactly 796.00", () => {
+  const masavFile = new MasaVSendPayments();
+  const institution = new InstitutionSendPayment(
+    "12345678", "12345", "200507", "200507", "Company ISRAEL LTD.", "404"
+  );
+  institution.addPaymentRecords(
+    AMOUNTS.map((amount, i) => new SendPaymentsRecord(
+      "11", "303", "007008629", "123123127", `Payee ${i}`, "00000000000001313131", amount
+    ))
+  );
+  masavFile.addInstitution(institution);
+  const record = sumRecord(masavFile.toBuffer());
+  expect(record.slice(21, 34)).toBe("0000000000796");
+  expect(record.slice(34, 36)).toBe("00");
+});

--- a/src/institutionGetPayment.ts
+++ b/src/institutionGetPayment.ts
@@ -111,7 +111,7 @@ export default class InstitutionGetPayment {
     );
     let sumAmount: number = this._payments
       .map((payment) => payment._amount)
-      .reduce((a, b) => a + b, 0);
+      .reduce((a, b) => a + Math.round(b * 100), 0) / 100;
     
     // Same as send payment but lines 7 & 8, and 9 & 10 are switched
     let sum = Buffer.concat([

--- a/src/institutionSendPayment.ts
+++ b/src/institutionSendPayment.ts
@@ -111,7 +111,7 @@ export default class InstitutionSendPayment {
     );
     let sumAmount: number = this._payments
       .map((payment) => payment._amount)
-      .reduce((a, b) => a + b, 0);
+      .reduce((a, b) => a + Math.round(b * 100), 0) / 100;
 
     let sum = Buffer.concat([
       Tools.stringToBuffer("5", 1, "X"),


### PR DESCRIPTION

## Problem

Payment amounts were accumulated as floating-point numbers, which could result in precision errors.

For example, aggregating 40 payments of 19.90 ₪ could produce:

```text
795.99999999999943
```

instead of:

```text
796.00
```

This is especially critical because the calculated total is later split into its whole and fractional parts when generating the payment file:

```ts
Math.floor(sumAmount) // 795
Math.round(sumAmount * 100) % 100 // 0
```

In this case, the floating-point precision error causes `Math.floor()` to return `795`, while the fractional part is calculated as `0`.

As a result, the generated payment file contains **795.00 ₪ instead of the correct 796.00 ₪ — a difference of 1 ₪**.

## Solution

Payment amounts are now converted to agorot using `Math.round(amount * 100)` before being accumulated. The final total is converted back to shekels after the aggregation.

This prevents floating-point precision errors from affecting the amount written to the payment file.


## Scope

The fix is applied to both aggregation paths:

- `src/institutionGetPayment.ts`
- `src/institutionSendPayment.ts` (same one-line fix)

## Tests

Added `src/__tests__/floatPrecision.test.ts` with regression tests for both the get and send files: 40 payments of 19.90 ₪ must produce exactly `796` / `00` in the sum record. Both tests fail without this fix (the file contains `795` / `00`) and pass with it.
